### PR TITLE
Generalize path construction in tests

### DIFF
--- a/testing/automated_testing.py
+++ b/testing/automated_testing.py
@@ -3,17 +3,17 @@ from testing import comparison_tests, other_tests
 
 
 if __name__ == "__main__":
-    svg_dir = f"{os.getcwd()}\\examples\\"
+    svg_dir = os.path.join(os.getcwd(), "examples")
     svg_names = {name[:-4] for name in os.listdir(svg_dir) if name[0] != '_'}
 
-    comparison_dir = f"{os.getcwd()}\\comparison_tests\\"
-    comparison_names = {name for name in os.listdir(comparison_dir) if os.path.isdir(comparison_dir + name)
+    comparison_dir = os.path.join(os.getcwd(), "comparison_tests")
+    comparison_names = {name for name in os.listdir(comparison_dir) if os.path.isdir(os.path.join(comparison_dir, name))
                         and name[0] != '_'}
 
-    other_dir = f"{os.getcwd()}\\other_tests\\"
-    other_names = {name for name in os.listdir(other_dir) if os.path.isdir(other_dir + name) and name[0] != '_'}
+    other_dir = os.path.join(os.getcwd(), "other_tests")
+    other_names = {name for name in os.listdir(other_dir) if os.path.isdir(os.path.join(other_dir, name)) and name[0] != '_'}
 
-    print("\nExecuting comparison tests...")
+    print(f"\nExecuting {len(comparison_names)} comparison tests...")
     for test_name in comparison_names:
 
         conflicts, missing_results = comparison_tests.run_tests(test_name, svg_names)
@@ -35,7 +35,7 @@ if __name__ == "__main__":
             print(f"The following examples are missing a verified result for the {test_name} test: {missing_results}")
             print(f"After verifying that the example-unverified.gcode is correct, rename it to example.gcode.\n")
 
-    print("\nExecuting other tests...")
+    print(f"\nExecuting {len(other_names)} other tests...")
     for test_name in other_names:
         conflicts = other_tests.run_tests(test_name, svg_names)
 

--- a/testing/comparison_tests/_run_tests.py
+++ b/testing/comparison_tests/_run_tests.py
@@ -11,9 +11,9 @@ def run_tests(test_name, examples):
     conflicts = []
     missing_results = []
     for svg_name in examples:
-        svg_file_name = f"{os.getcwd()}\\examples\\{svg_name}.svg"
-        correct_file_name = f"{os.getcwd()}\\comparison_tests\\{test_name}\\{svg_name}.gcode"
-        output_file_name = f"{os.getcwd()}\\comparison_tests\\{test_name}\\{svg_name}-unverified.gcode"
+        svg_file_name = os.path.join(os.getcwd(), "examples", f"{svg_name}.svg")
+        correct_file_name = os.path.join(os.getcwd(), "comparison_tests", test_name, f"{svg_name}.gcode")
+        output_file_name = os.path.join(os.getcwd(), "comparison_tests", test_name, f"{svg_name}-unverified.gcode")
 
         run_test = importlib.import_module(f"testing.comparison_tests.{test_name}.test").run_test
         with open(svg_file_name, 'rb') as svg_file:

--- a/testing/debug_example.py
+++ b/testing/debug_example.py
@@ -17,9 +17,9 @@ if __name__ == "__main__":
     if test_type == "comparison":
         run_test = importlib.import_module(f"testing.comparison_tests.{test_name}.test").run_test
 
-        input_path = f"examples\\{example}.svg"
-        correct_path = f"comparison_tests\\{test_name}\\{example}.gcode"
-        output_path = f"comparison_tests\\{test_name}\\{example}-unverified.gcode"
+        input_path = os.path.join("examples", f"{example}.svg")
+        correct_path = os.path.join("comparison_tests", test_name, f"{example}.gcode")
+        output_path = os.path.join("comparison_tests", test_name, f"{example}-unverified.gcode")
 
         with open(input_path, 'rb') as svg_file:
             svg_string = svg_file.read()
@@ -38,5 +38,5 @@ if __name__ == "__main__":
     if test_type == "other":
         run_test = importlib.import_module(f"testing.other_tests.{test_name}.test").run_test
 
-        debug_file_name = f"other_tests\\linear_approximation\\{example}.svg"
+        debug_file_name = os.path.join("other_tests", "linear_approximation", f"{example}.svg")
         print(run_test(example, debug_file_name))

--- a/testing/other_tests/_run_tests.py
+++ b/testing/other_tests/_run_tests.py
@@ -6,8 +6,8 @@ def run_tests(test_name, examples):
 
     conflicts = []
     for svg_name in examples:
-        svg_file_name = f"examples\\{svg_name}.svg"
-        debug_file_name = f"other_tests\\{test_name}\\{svg_name}.svg"
+        svg_file_name = os.path.join("examples", f"{svg_name}.svg")
+        debug_file_name = os.path.join("other_tests", test_name, f"{svg_name}.svg")
 
         run_test = importlib.import_module(f"testing.other_tests.{test_name}.test").run_test
         success = run_test(svg_file_name, debug_file_name)


### PR DESCRIPTION
This changes the way paths are constructed to use os.path.join() instead using of "\\" in format strings. This should construct paths properly across operating systems. The problem was identified on macos, where paths are separated by '/' instead of '\' like on Windows.
