### PR TITLE
Remove whitespace from feedrate command

### DIFF
--- a/svg_to_gcode/compiler/interfaces/_gcode.py
+++ b/svg_to_gcode/compiler/interfaces/_gcode.py
@@ -34,7 +34,7 @@ class Gcode(Interface):
 
         if self._current_speed != self._next_speed:
             self._current_speed = self._next_speed
-            command += f" F {self._current_speed}"
+            command += f" F{self._current_speed}"
 
         # Move if not 0 and not None
         command += f" X{x}" if x is not None else ''


### PR DESCRIPTION
The recent fix to remove whitespace from the G1 X/Y/Z directives missed the feedrate (F). This is the same fix for the feedrate.
