### PR TITLE
Update start vertex for absolute paths so the close_path directive works

### DIFF
--- a/svg_to_gcode/svg_parser/_path.py
+++ b/svg_to_gcode/svg_parser/_path.py
@@ -173,6 +173,8 @@ class Path:
         # Draw Curves
         def absolute_cubic_bazier(control1_x, control1_y, control2_x, control2_y, x, y):
 
+            self.start = Vector(x, y)
+
             trans_start = self._transform_coordinate_system(self.end)
             trans_end = self._transform_coordinate_system(Vector(x, y))
             trans_control1 = self._transform_coordinate_system(Vector(control1_x, control1_y))


### PR DESCRIPTION
Absolute paths need to update the start vertex so subsequent "close path" (z) command will work properly.

I am including a test case to reproduce the issue, along with screenshots. I generated the test by tracing an image in Inkscape, and the GCode was visualized with multiple online visualizers, which consistently showed the problem.

[bug_close_path.zip](https://github.com/PadLex/SvgToGcode/files/5976756/bug_close_path.zip)

I would guess this problem exists for some other commands, but I don't have test cases for them.